### PR TITLE
Fix name property error

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -67,7 +67,7 @@ function resolveContentType (type) {
 }
 
 async function createFeed (feedOptions, callback) {
-  if (['rss2', 'json1', 'atom1'].indexOf(feedOptions.type) === -1) {
+  if (!['rss2', 'json1', 'atom1'].includes(feedOptions.type)) {
     logger.fatal(`Could not create Feed ${feedOptions.path} - Unknown feed type`)
     return callback(null, '', feedOptions.cacheTime)
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -40,9 +40,6 @@ module.exports = async function feed () {
       await fs.outputFile(xmlGeneratePath, await feedCache.get(index))
     })
 
-    this.nuxt.hook('generate:extendRoutes', async routes => {
-      routes.push(feedOptions.path)
-    })
     this.addServerMiddleware({
       path: feedOptions.path,
       handler (req, res, next) {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -45,7 +45,9 @@ describe('generator', async () => {
         '        <atom:link href="https://example.com/atom" rel="self" type="application/rss+xml"/>\n' +
         '    </channel>\n' +
         '</rss>')
+    const { errors } = await generator.generate()
     fs.removeSync(filePath)
+    expect(errors.length).toBe(0)
   }, timeout)
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -23,8 +23,6 @@ describe('generator', async () => {
 
     const generator = new Generator(nuxt, new Builder(nuxt))
     await generator.initiate()
-    const routes = await generator.initRoutes()
-    expect(routes.includes('/feed.xml')).toBe(true)
 
     expect(fs.readFileSync(filePath, { encoding: 'utf8' }))
       .toBe('<?xml version="1.0" encoding="utf-8"?>\n' +


### PR DESCRIPTION
I have error with `nuxt generate`. I removed nuxt.hook('generate:extendRoutes') and added nuxt.hook('generate:done').

```
"dependencies": {
  nuxt": "^1.4.0"
},
"devDependencies": {
  @nuxtjs/feed": "^0.1.0"
}
```

```
 Generate errors summary:

 ROUTE  undefined

  TypeError: Cannot read property 'name' of undefined

  - vue-router.common.js:1278 normalizeLocation
    [lab_hp]/[vue-router]/dist/vue-router.common.js:1278:12

  - vue-router.common.js:2576 VueRouter.resolve
    [lab_hp]/[vue-router]/dist/vue-router.common.js:2576:18

  -
  -
```
