### PR TITLE
refactor: replace pify by util.promisify

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import AsyncCache from 'async-cache'
-import pify from 'pify'
+import { promisify } from 'util'
 import { Feed } from 'feed'
 import consola from 'consola'
 
@@ -30,7 +30,7 @@ export default async function feed () {
     }
   })
 
-  feedCache.get = pify(feedCache.get)
+  feedCache.get = promisify(feedCache.get)
 
   options.forEach((feedOptions, index) => {
     this.nuxt.hook('generate:before', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10403,11 +10403,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "async-cache": "^1.1.0",
     "consola": "^1.4.3",
     "feed": "^2.0.1",
-    "fs-extra": "^7.0.0",
-    "pify": "^3.0.0"
+    "fs-extra": "^7.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.2",


### PR DESCRIPTION
The native method `promisify(...)` is available since Node.js 8.0.0 

see https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original