### PR TITLE
move log error before fatal

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -74,8 +74,8 @@ async function createFeed (feedOptions, callback) {
     await feedOptions.create.call(this, feed)
     feed.options = Object.assign({ generator: 'https://github.com/nuxt-community/feed-module' }, feed.options)
   } catch (err) /* istanbul ignore next */ {
-    logger.fatal('Error while executing feed creation function')
     logger.error(err)
+    logger.fatal('Error while executing feed creation function')
   }
   return callback(null, feed[feedOptions.type](), feedOptions.cacheTime)
 }


### PR DESCRIPTION
_Fatal_ exits with error code 1. And `logger.error` wasn't reached.