### PR TITLE
fix: create parent directories if not exist in generate mode

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,6 +1,7 @@
 const { join, resolve } = require('path')
 const { promisify } = require('util')
-const { writeFileSync } = require('fs')
+const { existsSync, mkdirSync, writeFileSync } = require('fs')
+const { dirname } = require('path')
 const { Feed } = require('feed')
 const AsyncCache = require('async-cache')
 const logger = require('./logger')
@@ -32,7 +33,11 @@ module.exports = async function (moduleOptions) {
       }
 
       const xmlGeneratePath = resolve(this.options.rootDir, join(this.options.generate.dir, feedOptions.path))
+      const xmlGenerateDirPath = dirname(xmlGeneratePath)
 
+      if (!existsSync(xmlGenerateDirPath)) {
+        mkdirSync(xmlGenerateDirPath, { recursive: true })
+      }
       writeFileSync(xmlGeneratePath, await feedCache.get(index))
 
       logger.success('Generated', feedOptions.path)

--- a/test/__snapshots__/module.test.js.snap
+++ b/test/__snapshots__/module.test.js.snap
@@ -62,6 +62,26 @@ exports[`module generate simple rss 1`] = `
 </rss>"
 `;
 
+exports[`module generate simple rss in subdir 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
+<rss version=\\"2.0\\">
+    <channel>
+        <title>Feed Title</title>
+        <link>http://example.com/</link>
+        <description>This is my personal feed!</description>
+        <lastBuildDate>Fri, 14 Jul 2000 00:00:00 GMT</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>awesome</generator>
+        <image>
+            <title>Feed Title</title>
+            <url>http://example.com/image.png</url>
+            <link>http://example.com/</link>
+        </image>
+        <copyright>All rights reserved 2013, John Doe</copyright>
+    </channel>
+</rss>"
+`;
+
 exports[`module multi rss 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <rss version=\\"2.0\\">

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -37,6 +37,18 @@ describe('module', () => {
     expect(readFileSync(filePath, { encoding: 'utf8' })).toMatchSnapshot()
   })
 
+  test('generate simple rss in subdir', async () => {
+    ({ nuxt } = await generate({
+      ...config,
+      feed: [
+        { ...createFeed(), ...{ path: join('/feeds/articles', 'feed.xml') } }
+      ]
+    }))
+
+    const filePath = resolve(nuxt.options.rootDir, join(nuxt.options.generate.dir, '/feeds/articles', 'feed.xml'))
+    expect(readFileSync(filePath, { encoding: 'utf8' })).toMatchSnapshot()
+  })
+
   test('simple rss', async () => {
     ({ nuxt } = await setup(config))
 


### PR DESCRIPTION
Make sure to create all parents directories for the output feed files in "generate mode".

Since commit [8832f39](https://github.com/nuxt-community/feed-module/commit/8832f39bf02af7dcacb6115fbd45318e9b633be6#diff-d1234a869b3d648ebfcdce5a76747d71R3), the usage of `fs-extra.outputFile` has been replaced with `fs.writeFileSync`. However, there is a subtle behavior change: while `fs-extra.outputFile` was [creating all parent directories automatically](https://github.com/jprichardson/node-fs-extra/blob/master/docs/outputFile.md#outputfilefile-data-options-callback), `fs.writeFileSync` [does not](https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options). Thus all parent directories need to be created if not present already.
Resolves #85.