### PR TITLE
Quality: parseOptions can throw when `feed` options are undefined or null

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -64,6 +64,10 @@ async function parseOptions (options) {
     options = await options()
   }
 
+  if (!options) {
+    return []
+  }
+
   // Factory object
   if (!Array.isArray(options)) {
     if (options.factory) {


### PR DESCRIPTION
## Problem

`parseOptions` calls `Object.keys(options)` without guarding against `undefined`/`null`. If neither `this.options.feed` nor `moduleOptions` is provided, this will throw a runtime error during module initialization instead of treating it as an empty config.

**Severity**: `high`
**File**: `lib/module.js`

## Solution

Add an early guard before `Object.keys`, e.g. `if (!options) return []`, and optionally validate object shape before accessing `options.factory`.

## Changes

- `lib/module.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
